### PR TITLE
docs: fix repository folder name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A blockchain-powered property escrow platform that simplifies complex real estat
 1. **Clone the repository**
 ```bash
 git clone <repository-url>
-cd PropertyEscrow
+cd PropertyEscrowPlatform
 ```
 
 2. **Install dependencies**


### PR DESCRIPTION
## Summary
- correct the repository folder name in the installation steps

## Testing
- `grep -n "cd PropertyEscrowPlatform" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68434563de24832e8df425610c3d0ac2